### PR TITLE
Fixing issue if CloudFormation resource name is longer than maximum a…

### DIFF
--- a/cfn_policy_validator/parsers/identity.py
+++ b/cfn_policy_validator/parsers/identity.py
@@ -136,7 +136,9 @@ class RoleParser(PrincipalParser):
 
 		path = properties.get('Path', '/')
 		trust_policy = properties['AssumeRolePolicyDocument']
-		role_name = properties.get('RoleName', resource_name)
+
+		# if RoleName is not a property, use the resource name and truncate to max role length
+		role_name = properties.get('RoleName', resource_name[:64])
 
 		role = Role(role_name, path, trust_policy)
 

--- a/cfn_policy_validator/tests/parsers_tests/test_identity_roles.py
+++ b/cfn_policy_validator/tests/parsers_tests/test_identity_roles.py
@@ -352,6 +352,29 @@ class WhenParsingAnIAMRoleWithNoNameOrPath(IdentityParserTest):
 		self.assertEqual(assume_role_policy_doc, role.TrustPolicy)
 		self.assertEqual(0, len(role.Policies))
 
+	# Role Name length max is 64 characters
+	def test_long_role_name_is_truncated(self):
+		role_name = 'ResourceA123456789123456789123456789123456789123456789123456789123456789'
+		template = load({
+			'Resources': {
+				'ResourceA123456789123456789123456789123456789123456789123456789123456789': {
+					'Type': 'AWS::IAM::Role',
+					'Properties': {
+						'AssumeRolePolicyDocument': copy.deepcopy(assume_role_policy_doc)
+					}
+				}
+			}
+		})
+
+		self.parse(template, account_config)
+		self.assertResults(number_of_roles=1)
+
+		role = self.roles[0]
+		self.assertEqual(role_name[:64], role.RoleName)
+		self.assertEqual("/", role.RolePath)
+		self.assertEqual(assume_role_policy_doc, role.TrustPolicy)
+		self.assertEqual(0, len(role.Policies))
+
 
 class WhenParsingAnIAMPolicyAttachedToARole(IdentityParserTest):
 	def test_returns_a_role_and_policy(self):


### PR DESCRIPTION
…llowed IAM RoleName length.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
