### PR TITLE
fix: return Name property on Fn::Sub of AWS::SSM::Parameter resource

### DIFF
--- a/cfn_policy_validator/parsers/utils/intrinsic_functions/__init__.py
+++ b/cfn_policy_validator/parsers/utils/intrinsic_functions/__init__.py
@@ -6,5 +6,6 @@ name_hints = {
 	'AWS::IAM::Role': 'RoleName',
 	'AWS::IAM::User': 'UserName',
 	'AWS::IAM::Group': 'GroupName',
-	'AWS::SQS::Queue': 'QueueName'
+	'AWS::SQS::Queue': 'QueueName',
+	'AWS::SSM::Parameter': 'Name',
 }


### PR DESCRIPTION
Access Analyzer is smart enough to know that ARNs for SSM Parameters take the form of arn:aws:ssm:REGION:ACCOUNTID:parameter/path/to/param. If the resource part of the ARN doesn't contain slashes '/', then Access Analyzer throws an error that the ARN is malformed. That's exactly what happens if the logical id of the parameter is substituted in a Fn::Sub call to a parameter resource.

This commit adds 'AWS::SSM::Parameter' to the name hints dict so that the value of the resource's 'Name' property is substituted instead of the logical id. A template like this now passes validation (and fails prior to this commit):

    FunctionRole:
        Type: AWS::IAM::Role
        Properties:
            AssumeRolePolicyDocument:
                Version: "2012-10-17"
                Statement:
                    - Effect: Allow
                      Action:
                          - sts:AssumeRole
                      Principal:
                          Service:
                              - lambda.amazonaws.com
            Policies:
                - PolicyDocument:
                    Version: "2012-10-17"
                    Statement:
                        - Sid: ParameterStore
                          Effect: Allow
                          Action:
                              - ssm:GetParameter
                          Resource:
                              - !Sub "arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter${MyParameter}"
                  PolicyName: Policy

    MyParameter:
        Type: AWS::SSM::Parameter
        Properties:
            Name: /stuff/and/things/param
            Type: String
            Value: cloud
