### PR TITLE
Migrate to jsonschema>=4.21.0 and python 3.8-3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python: [3.7, 3.8, 3.9]
+        python: [3.8. 3.9, 3.10, 3.11, 3.12]
 
     steps:
       - uses: actions/checkout@v2

--- a/cfn_policy_validator/cfn_tools/schema_validator.py
+++ b/cfn_policy_validator/cfn_tools/schema_validator.py
@@ -72,8 +72,9 @@ def validate(template):
 
 
 def validate_schema(instance, schema, parent_path=None):
+	validator = jsonschema.Draft201909Validator(schema=schema)
 	try:
-		jsonschema.validate(instance=instance, schema=schema)
+		validator.validate(instance=instance)
 	except ValidationError as e:
 		message = e.message
 

--- a/cfn_policy_validator/tests/cfn_tools_tests/test_schema_validator.py
+++ b/cfn_policy_validator/tests/cfn_tools_tests/test_schema_validator.py
@@ -10,7 +10,7 @@ import yaml
 from cfn_policy_validator.application_error import ApplicationError
 from cfn_policy_validator.cfn_tools.schema_validator import validate
 from cfn_policy_validator.cfn_tools.yaml_loader import CfnYamlLoader
-from cfn_policy_validator.tests.utils import expected_type_error, required_property_error
+from cfn_policy_validator.tests.utils import expected_type_error, required_property_error, should_be_non_empty_error
 
 
 def load(template):
@@ -213,7 +213,7 @@ class WhenParsingTemplateAndValidatingSchema(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			validate(template)
 
-		self.assertEqual("{} does not have enough properties, Path: Mappings.FirstLevel1", str(cm.exception))
+		self.assertEqual(should_be_non_empty_error('Mappings.FirstLevel1', '{}'), str(cm.exception))
 
 	def test_template_has_invalid_second_level_mappings_type(self):
 		template = load({
@@ -243,7 +243,7 @@ class WhenParsingTemplateAndValidatingSchema(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			validate(template)
 
-		self.assertEqual("{} does not have enough properties, Path: Mappings.FirstLevel1.SecondLevel1", str(cm.exception))
+		self.assertEqual(should_be_non_empty_error('Mappings.FirstLevel1.SecondLevel1', '{}'), str(cm.exception))
 
 	def test_template_has_invalid_third_level_mappings_type(self):
 		template = load({

--- a/cfn_policy_validator/tests/parsers_tests/resource_tests/test_sns.py
+++ b/cfn_policy_validator/tests/parsers_tests/resource_tests/test_sns.py
@@ -9,7 +9,7 @@ from cfn_policy_validator.parsers.resource.parser import ResourceParser
 from cfn_policy_validator.parsers.output import Resource, Policy
 from cfn_policy_validator.tests.parsers_tests import mock_node_evaluator_setup
 
-from cfn_policy_validator.tests.utils import required_property_error, load, account_config, expected_type_error, \
+from cfn_policy_validator.tests.utils import required_property_error, account_config, expected_type_error, should_be_non_empty_error, \
 	load_resources
 from cfn_policy_validator.application_error import ApplicationError
 
@@ -146,7 +146,7 @@ class WhenParsingAnSnsTopicPolicyAndValidatingSchema(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			ResourceParser.parse(template, account_config)
 
-		self.assertEqual('[] is too short, Path: Resources.ResourceA.Properties.Topics', str(cm.exception))
+		self.assertEqual(should_be_non_empty_error("Resources.ResourceA.Properties.Topics", "[]"), str(cm.exception))
 
 	@mock_node_evaluator_setup()
 	def test_with_invalid_topics_item_type(self):

--- a/cfn_policy_validator/tests/parsers_tests/resource_tests/test_sqs.py
+++ b/cfn_policy_validator/tests/parsers_tests/resource_tests/test_sqs.py
@@ -10,7 +10,7 @@ from cfn_policy_validator.parsers.output import Resource, Policy
 from cfn_policy_validator.tests.parsers_tests import mock_node_evaluator_setup
 
 from cfn_policy_validator.tests.utils import required_property_error, load, account_config, expected_type_error, \
-	load_resources
+	should_be_non_empty_error, load_resources
 from cfn_policy_validator.application_error import ApplicationError
 
 
@@ -147,7 +147,7 @@ class WhenParsingAnSqsQueuePolicyAndValidatingSchema(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			ResourceParser.parse(template, account_config)
 
-		self.assertEqual('[] is too short, Path: Resources.ResourceA.Properties.Queues', str(cm.exception))
+		self.assertEqual(should_be_non_empty_error('Resources.ResourceA.Properties.Queues', '[]'), str(cm.exception))
 
 	@mock_node_evaluator_setup()
 	def test_with_invalid_queues_item_type(self):

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_if_evaluator.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_if_evaluator.py
@@ -32,7 +32,7 @@ class WhenEvaluatingAConditionWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Conditions']['myCondition'])
-        self.assertEquals(result, 'a')
+        self.assertEqual(result, 'a')
 
     @mock_node_evaluator_setup()
     def test_comparison_is_false(self):
@@ -57,7 +57,7 @@ class WhenEvaluatingAConditionWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Conditions']['myCondition'])
-        self.assertEquals(result, 'b')
+        self.assertEqual(result, 'b')
 
     @mock_node_evaluator_setup()
     def test_condition_with_name_does_not_exist(self):
@@ -102,7 +102,7 @@ class WhenEvaluatingAConditionWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Conditions']['myCondition'])
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     @mock_node_evaluator_setup()
     def test_comparison_is_false_and_result_is_function(self):
@@ -125,7 +125,7 @@ class WhenEvaluatingAConditionWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Conditions']['myCondition'])
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
 
 class WhenEvaluatingAResourceWithAnIfFunction(unittest.TestCase):
@@ -156,7 +156,7 @@ class WhenEvaluatingAResourceWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
-        self.assertEquals(result, 'a')
+        self.assertEqual(result, 'a')
 
     @mock_node_evaluator_setup()
     def test_comparison_is_false(self):
@@ -185,7 +185,7 @@ class WhenEvaluatingAResourceWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
-        self.assertEquals(result, 'b')
+        self.assertEqual(result, 'b')
 
     @mock_node_evaluator_setup()
     def test_condition_with_name_does_not_exist(self):
@@ -240,7 +240,7 @@ class WhenEvaluatingAResourceWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
     @mock_node_evaluator_setup()
     def test_comparison_is_false_and_result_is_function(self):
@@ -269,7 +269,7 @@ class WhenEvaluatingAResourceWithAnIfFunction(unittest.TestCase):
         node_evaluator = build_node_evaluator(template)
 
         result = node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
-        self.assertEquals(result, True)
+        self.assertEqual(result, True)
 
 
 class WhenEvaluatingAConditionWithAnIfFunctionThatDoesNotMatchSchema(unittest.TestCase):

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_not_evaluator.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_not_evaluator.py
@@ -6,7 +6,7 @@ import unittest
 
 from cfn_policy_validator import ApplicationError
 from cfn_policy_validator.tests.parsers_tests import mock_node_evaluator_setup
-from cfn_policy_validator.tests.utils import load, build_node_evaluator, expected_type_error, too_short_error, \
+from cfn_policy_validator.tests.utils import load, build_node_evaluator, expected_type_error, should_be_non_empty_error, \
     too_long_error
 
 
@@ -108,7 +108,7 @@ class WhenEvaluatingAConditionWithANotFunctionThatDoesNotMatchSchema(unittest.Te
         with self.assertRaises(ApplicationError) as cm:
             node_evaluator.eval(template['Conditions']['myCondition'])
 
-        self.assertEqual(too_short_error("Fn::Not", "[]"), str(cm.exception))
+        self.assertEqual(should_be_non_empty_error("Fn::Not", "[]"), str(cm.exception))
 
     @mock_node_evaluator_setup()
     def test_function_has_list_with_more_than_one_elements(self):

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_sub_evaluator.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_sub_evaluator.py
@@ -7,7 +7,7 @@ import unittest
 from cfn_policy_validator.application_error import ApplicationError
 from cfn_policy_validator.tests.parsers_tests import mock_node_evaluator_setup
 from cfn_policy_validator.tests.utils import load, account_config, load_resources, expected_type_error, \
-	build_node_evaluator
+	expected_schema_error, build_node_evaluator
 
 
 class WhenEvaluatingAPropertyWithASubThatResolvesToGetAtt(unittest.TestCase):
@@ -111,7 +111,7 @@ class WhenEvaluatingAPropertyWithASubThatDoesNotResolveToAString(unittest.TestCa
 		with self.assertRaises(ApplicationError) as cm:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-		self.assertEqual(expected_type_error('Fn::Sub', 'string', "['Invalid']"), str(cm.exception))
+			self.assertEqual(expected_type_error('Fn::Sub', 'string', "['Invalid']"), str(cm.exception))
 
 
 class WhenEvaluatingAPropertyWithALongFormSub(unittest.TestCase):
@@ -263,8 +263,7 @@ class WhenEvaluatingLongFormSubAndGetAttIsNotFound(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyB'])
 
-		self.assertEqual('Unable to find referenced resource for GetAtt reference to ResourceB.PropertyB',
-						 str(cm.exception))
+			self.assertEqual('Unable to find referenced resource for GetAtt reference to ResourceB.PropertyB', str(cm.exception))
 
 
 class WhenEvaluatingLongFormSubAndRefIsNotFound(unittest.TestCase):
@@ -291,8 +290,7 @@ class WhenEvaluatingLongFormSubAndRefIsNotFound(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyB'])
 
-		self.assertEqual('Unable to find a referenced resource or parameter in template: MissingParam',
-						 str(cm.exception))
+			self.assertEqual('Unable to find a referenced resource or parameter in template: MissingParam', str(cm.exception))
 
 
 class WhenEvaluatingAPropertyWithInvalidSubValue(unittest.TestCase):
@@ -319,7 +317,7 @@ class WhenEvaluatingAPropertyWithInvalidSubValue(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-		self.assertEqual(expected_type_error('Fn::Sub', 'array or string', {'Ref': 'Invalid'}), str(context.exception))
+			self.assertEqual(expected_schema_error('Fn::Sub', {'Ref': 'Invalid'}), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubOfInvalidLength(unittest.TestCase):
@@ -346,9 +344,7 @@ class WhenEvaluatingAPropertyWithLongFormSubOfInvalidLength(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-		self.assertEqual(
-			"Additional items are not allowed ('3rd' was unexpected), Path: Fn::Sub",
-			str(context.exception))
+			self.assertEqual("Additional items are not allowed ('3rd' was unexpected), Path: Fn::Sub", str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubWithInvalidTextToEvaluate(unittest.TestCase):
@@ -370,7 +366,7 @@ class WhenEvaluatingAPropertyWithLongFormSubWithInvalidTextToEvaluate(unittest.T
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-		self.assertEqual(expected_type_error("Fn::Sub.0", 'string', "['www.${Domain}']"), str(context.exception))
+			self.assertEqual(expected_type_error("Fn::Sub.0", 'string', "['www.${Domain}']"), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubWithInvalidMapping(unittest.TestCase):
@@ -397,7 +393,7 @@ class WhenEvaluatingAPropertyWithLongFormSubWithInvalidMapping(unittest.TestCase
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-		self.assertEqual(expected_type_error('Fn::Sub.1', 'object', "'Domain'"), str(context.exception))
+			self.assertEqual(expected_type_error('Fn::Sub.1', 'object', "'Domain'"), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubAndNoMatchingMapping(unittest.TestCase):
@@ -423,7 +419,4 @@ class WhenEvaluatingAPropertyWithLongFormSubAndNoMatchingMapping(unittest.TestCa
 
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
-
-		self.assertEqual(
-			"Unable to find a referenced resource or parameter in template: Domain",
-			str(context.exception))
+			self.assertEqual("Unable to find a referenced resource or parameter in template: Domain", str(context.exception))

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_sub_evaluator.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_sub_evaluator.py
@@ -111,7 +111,7 @@ class WhenEvaluatingAPropertyWithASubThatDoesNotResolveToAString(unittest.TestCa
 		with self.assertRaises(ApplicationError) as cm:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-			self.assertEqual(expected_type_error('Fn::Sub', 'string', "['Invalid']"), str(cm.exception))
+		self.assertEqual(expected_type_error('Fn::Sub', 'string', "['Invalid']"), str(cm.exception))
 
 
 class WhenEvaluatingAPropertyWithALongFormSub(unittest.TestCase):
@@ -263,7 +263,7 @@ class WhenEvaluatingLongFormSubAndGetAttIsNotFound(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyB'])
 
-			self.assertEqual('Unable to find referenced resource for GetAtt reference to ResourceB.PropertyB', str(cm.exception))
+		self.assertEqual('Unable to find referenced resource for GetAtt reference to ResourceB.PropertyB', str(cm.exception))
 
 
 class WhenEvaluatingLongFormSubAndRefIsNotFound(unittest.TestCase):
@@ -290,7 +290,7 @@ class WhenEvaluatingLongFormSubAndRefIsNotFound(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as cm:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyB'])
 
-			self.assertEqual('Unable to find a referenced resource or parameter in template: MissingParam', str(cm.exception))
+		self.assertEqual('Unable to find a referenced resource or parameter in template: MissingParam', str(cm.exception))
 
 
 class WhenEvaluatingAPropertyWithInvalidSubValue(unittest.TestCase):
@@ -317,7 +317,7 @@ class WhenEvaluatingAPropertyWithInvalidSubValue(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-			self.assertEqual(expected_schema_error('Fn::Sub', {'Ref': 'Invalid'}), str(context.exception))
+		self.assertEqual(expected_schema_error('Fn::Sub', "{'Ref': 'Invalid'}"), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubOfInvalidLength(unittest.TestCase):
@@ -344,7 +344,7 @@ class WhenEvaluatingAPropertyWithLongFormSubOfInvalidLength(unittest.TestCase):
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-			self.assertEqual("Additional items are not allowed ('3rd' was unexpected), Path: Fn::Sub", str(context.exception))
+		self.assertEqual(expected_schema_error('Fn::Sub', "['www.${Domain}', {'Domain': 'abc'}, '3rd']"), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubWithInvalidTextToEvaluate(unittest.TestCase):
@@ -366,7 +366,7 @@ class WhenEvaluatingAPropertyWithLongFormSubWithInvalidTextToEvaluate(unittest.T
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-			self.assertEqual(expected_type_error("Fn::Sub.0", 'string', "['www.${Domain}']"), str(context.exception))
+		self.assertEqual(expected_schema_error("Fn::Sub", "[['www.${Domain}'], {'Domain': 'abc'}]"), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubWithInvalidMapping(unittest.TestCase):
@@ -393,7 +393,7 @@ class WhenEvaluatingAPropertyWithLongFormSubWithInvalidMapping(unittest.TestCase
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
 
-			self.assertEqual(expected_type_error('Fn::Sub.1', 'object', "'Domain'"), str(context.exception))
+		self.assertEqual(expected_schema_error("Fn::Sub", "['www.${Domain}', 'Domain']"), str(context.exception))
 
 
 class WhenEvaluatingAPropertyWithLongFormSubAndNoMatchingMapping(unittest.TestCase):
@@ -419,4 +419,4 @@ class WhenEvaluatingAPropertyWithLongFormSubAndNoMatchingMapping(unittest.TestCa
 
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
-			self.assertEqual("Unable to find a referenced resource or parameter in template: Domain", str(context.exception))
+		self.assertEqual("Unable to find a referenced resource or parameter in template: Domain", str(context.exception))

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/test_topological_sort.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/test_topological_sort.py
@@ -7,7 +7,7 @@ import unittest
 from cfn_policy_validator.application_error import ApplicationError
 from cfn_policy_validator.parsers.utils.topological_sorter import TopologicalSorter
 from cfn_policy_validator.tests.parsers_tests import mock_node_evaluator_setup
-from cfn_policy_validator.tests.utils import load, expected_type_error
+from cfn_policy_validator.tests.utils import load, expected_type_error, expected_schema_error
 
 
 def get_index_of(sorted_resources, name):
@@ -263,7 +263,7 @@ class WhenSortingWithSubDependencies(unittest.TestCase):
         with self.assertRaises(ApplicationError) as cm:
             sorter.sort_resources()
 
-        self.assertEqual(expected_type_error('Fn::Sub', 'array or string', "{'ResourceA': 'Blah'}"), str(cm.exception))
+        self.assertEqual(expected_schema_error('Fn::Sub', "{'ResourceA': 'Blah'}"), str(cm.exception))
 
 
 class WhenSortingWithExplicitDependsOn(unittest.TestCase):

--- a/cfn_policy_validator/tests/utils.py
+++ b/cfn_policy_validator/tests/utils.py
@@ -42,12 +42,20 @@ def expected_type_error(path: str, expected_type: str, actual_value: str):
     return f"{actual_value} is not of type '{expected_type}', Path: {path}"
 
 
+def expected_schema_error(path: str, actual_value: str):
+    return f"{actual_value} is not valid under any of the given schemas, Path: {path}"
+
+
 def too_short_error(path: str, actual_value: str):
     return f"{actual_value} is too short, Path: {path}"
 
 
 def too_long_error(path: str, actual_value: str):
     return f"{actual_value} is too long, Path: {path}"
+
+
+def should_be_non_empty_error(path: str, actual_value: str):
+    return f"{actual_value} should be non-empty, Path: {path}"
 
 
 @contextmanager

--- a/setup.py
+++ b/setup.py
@@ -36,13 +36,14 @@ setuptools.setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
     entry_points={"console_scripts": "cfn-policy-validator=cfn_policy_validator.main:main"},
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     package_data={
         '': ['*.json']
     },
@@ -50,6 +51,6 @@ setuptools.setup(
         'boto3>=1.20',
         'pyYAML>=5.3',
         'urllib3>=1.25',
-        'jsonschema~=3.2'
+        'jsonschema>=4.21'
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py{36,37,38,39}
-
+envlist = py{38,39,310,311,312}
 [testenv]
 commands =
   pip install -e .


### PR DESCRIPTION

**Issue #, if available:**

[Fixes Issue #34](https://github.com/awslabs/aws-cloudformation-iam-policy-validator/issues/34)

**Description of changes:**

- unpin and update jsonschema dependency to most recent version
- Migrate tests that broke due to differently worded error messages in the new `jsonschema` version.
- Explicitly use validator for [Jsonschema Draft 2019](https://json-schema.org/draft/2019-09/release-notes) to keep the behaviour stable.
- run and test on supported python version range 3.8 to 3.12
- Resolve a DeprecationWarning for `unittest.TestCase.assertEquals` that broke with python 3.12

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
