### PR TITLE
Update boto3 dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setuptools.setup(
         '': ['*.json']
     },
     install_requires=[
-        'boto3>=1.20',
+        'boto3>=1.34.110',
         'pyYAML>=5.3',
         'urllib3>=1.25',
         'jsonschema>=4.21'


### PR DESCRIPTION
Boto3 dependency was too low to discover Custom checks in the AWS SDK, so if the user had a sufficient version but the version did not contain an updated AWS SDK, it would error.

Updated Boto3 dependency to latest version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
