### PR TITLE
Bugfix - Error when template only contains a role trust policy and no other supported resources

### DIFF
--- a/cfn_policy_validator/validation/policy_analysis.py
+++ b/cfn_policy_validator/validation/policy_analysis.py
@@ -34,6 +34,8 @@ CHECK_NO_PUBLIC_ACCESS_SUPPORTED_TYPES = {
 	"AWS::IAM::AssumeRolePolicyDocument"	
 }
 
+ASSUME_ROLE_POLICY_TYPE = "AWS::IAM::AssumeRolePolicyDocument"
+
 def get_identity_resource_name(resource):
 	if isinstance(resource, PermissionSet):
 		return resource.Name
@@ -365,12 +367,12 @@ class PublicAccessChecker(PolicyAnalysis):
 				raise ApplicationError(f'Unable to find trust policy for {role.RoleName}')
 			else:
 				policy_str = json.dumps(role.TrustPolicy)
-				if (policy_str, resource.ResourceType) not in self.resource_policy_cache:
+				if (policy_str, ASSUME_ROLE_POLICY_TYPE) not in self.resource_policy_cache:
 					LOGGER.info(f'Check trust policy for role {role.RoleName}')
-					response = self._call_api(role.TrustPolicy, RESOURCE_POLICY_TYPE, "AWS::IAM::AssumeRolePolicyDocument")
+					response = self._call_api(role.TrustPolicy, RESOURCE_POLICY_TYPE, ASSUME_ROLE_POLICY_TYPE)
 					LOGGER.info(f'{self.operation_name} response {response}')
-					self.resource_policy_cache[(policy_str, resource.ResourceType)] = response
+					self.resource_policy_cache[(policy_str, ASSUME_ROLE_POLICY_TYPE)] = response
 				else:
 					LOGGER.info(f'Trust policy for role {role.RoleName} already checked. Skipped.')
-					response = self.resource_policy_cache.get((policy_str, resource.ResourceType))
+					response = self.resource_policy_cache.get((policy_str, ASSUME_ROLE_POLICY_TYPE))
 				self._handle_response(response, role.RoleName, 'TrustPolicy', self.operation_name)


### PR DESCRIPTION
*Description of changes:*
Bugfix for `UnboundLocalError: local variable 'resource' referenced before assignment` error when checking a template that only contains a role with trust policy and no other supported resource types.

Tested fix against a template containing only a role with trust policy and no other supported resource types. Tested against roles with no expected findings and public access findings and received expected results.

Input:
```
  MyRole:
    Type: AWS::IAM::Role
    Properties:
      AssumeRolePolicyDocument:
        Version: '2012-10-17'
        Statement:
        - Effect: Allow
          Principal:
            AWS: 
            - "*"
          Action: 
          - sts:AssumeRole
```
Result:
```
{
    "BlockingFindings": [
        {
            "findingType": "SECURITY_WARNING",
            "code": "policy-analysis-CheckNoPublicAccess",
            "message": "The resource policy grants public access for the given resource type.",
```

Input:
```
MyRole:
    Type: AWS::IAM::Role
    Properties:
      AssumeRolePolicyDocument:
        Version: '2012-10-17'
        Statement:
        - Effect: Allow
          Principal:
            Service: 
            - ec2.amazonaws.com
          Action: 
          - sts:AssumeRole
```

Result:
```
{
    "BlockingFindings": [],
    "NonBlockingFindings": []
}
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
