### PR TITLE
Adding support and guidance for custom resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ Creating an access preview for a SecretsManager Secret requires a KMSKeyId.  The
 
 CheckNoPublicAccess custom policy checks differ from Access Previews because CheckNoPublicAccess checks do not require any account or external access analyzer context. Note that a charge is associated with each custom policy check.
 
+### How are custom resources handled?
+
+Custom resources (`Custom::*` and `AWS::CloudFormation::CustomResource`) have return values defined by the backing Lambda function or SNS topic, so the tool cannot determine what ARN they produce. If a custom resource exists in your template but is not referenced by any IAM policy, it is silently ignored. If an IAM policy references a custom resource via `Fn::GetAtt`, the tool will return an error because it cannot resolve the value and therefore cannot validate the policy. In this case, you can use `--exclude-resource-types Custom::MyResourceType` to skip validation for that resource type. Note that excluding a resource type means any policies referencing it will not be validated. 
 
 ### Examples
 

--- a/cfn_policy_validator/parsers/utils/arn_generator.py
+++ b/cfn_policy_validator/parsers/utils/arn_generator.py
@@ -66,6 +66,12 @@ class ArnGenerator:
             visited_nodes = []
 
         cfn_type = resource['Type']
+
+        # Custom resources (Custom::* and AWS::CloudFormation::CustomResource) have return values
+        # defined by the backing Lambda/SNS, so we cannot generate an ARN for them.
+        if cfn_type.startswith('Custom::') or cfn_type == 'AWS::CloudFormation::CustomResource':
+            return None
+
         split_cfn_type = cfn_type.split("::")
         if len(split_cfn_type) != 3:
             if len(split_cfn_type) == 4 and split_cfn_type[3].lower() == 'module':

--- a/cfn_policy_validator/parsers/utils/intrinsic_functions/fn_get_att_evaluator.py
+++ b/cfn_policy_validator/parsers/utils/intrinsic_functions/fn_get_att_evaluator.py
@@ -81,6 +81,16 @@ class GetAttEvaluator:
 		if arn is not None:
 			return arn
 
+		# Custom resources have return values defined by the backing Lambda/SNS, so we cannot determine
+		# what ARN they produce. Provide a helpful error directing users to --exclude-resource-types.
+		if resource_type.startswith('Custom::') or resource_type == 'AWS::CloudFormation::CustomResource':
+			raise ApplicationError(
+				f'Unable to resolve Fn::GetAtt for custom resource: {logical_name_of_resource}.{attribute_name}. '
+				f'Custom resource return values are defined by the backing Lambda function and cannot be resolved. '
+				f'If this resource is referenced in an IAM policy, you can exclude it from validation using '
+				f'--exclude-resource-types {resource_type}'
+			)
+
 		# if the GetAtt does not reference an ARN, see if we have a custom evaluation for this get_att.
 		# Useful in cases where an attribute returns something other than an ARN that's relevant to
 		# IAM policies (canonical username)

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_get_att_evaluator.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/intrinsic_functions_tests/test_get_att_evaluator.py
@@ -291,3 +291,59 @@ class WhenEvaluatingAPolicyWithAGetAttForANestedDottedAttribute(unittest.TestCas
 		with self.assertRaises(ApplicationError) as context:
 			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PolicyProperty'])
 		self.assertEqual('Call to GetAtt not supported for: RdsDbCluster.MasterUserSecret.SecretArn', str(context.exception))
+
+
+class WhenEvaluatingAPolicyWithAGetAttToACustomResource(unittest.TestCase):
+	@mock_node_evaluator_setup()
+	def test_raises_helpful_error_for_custom_prefix(self):
+		template = load_resources({
+			'ResourceA': {
+				'Type': 'AWS::Random::Service',
+				'Properties': {
+					'PropertyA': {
+						'Fn::GetAtt': ['MyCustomResource', 'Arn']
+					}
+				}
+			},
+			'MyCustomResource': {
+				'Type': 'Custom::MyLambdaBacked',
+				'Properties': {
+					'ServiceToken': 'arn:aws:lambda:us-east-1:123456789012:function:MyFunction'
+				}
+			}
+		})
+
+		node_evaluator = build_node_evaluator(template)
+
+		with self.assertRaises(ApplicationError) as context:
+			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
+
+		self.assertIn('Unable to resolve Fn::GetAtt for custom resource', str(context.exception))
+		self.assertIn('--exclude-resource-types', str(context.exception))
+
+	@mock_node_evaluator_setup()
+	def test_raises_helpful_error_for_cloudformation_custom_resource(self):
+		template = load_resources({
+			'ResourceA': {
+				'Type': 'AWS::Random::Service',
+				'Properties': {
+					'PropertyA': {
+						'Fn::GetAtt': ['MyCustomResource', 'Arn']
+					}
+				}
+			},
+			'MyCustomResource': {
+				'Type': 'AWS::CloudFormation::CustomResource',
+				'Properties': {
+					'ServiceToken': 'arn:aws:lambda:us-east-1:123456789012:function:MyFunction'
+				}
+			}
+		})
+
+		node_evaluator = build_node_evaluator(template)
+
+		with self.assertRaises(ApplicationError) as context:
+			node_evaluator.eval(template['Resources']['ResourceA']['Properties']['PropertyA'])
+
+		self.assertIn('Unable to resolve Fn::GetAtt for custom resource', str(context.exception))
+		self.assertIn('--exclude-resource-types', str(context.exception))

--- a/cfn_policy_validator/tests/parsers_tests/utils_tests/test_arn_generator.py
+++ b/cfn_policy_validator/tests/parsers_tests/utils_tests/test_arn_generator.py
@@ -74,6 +74,29 @@ class WhenGeneratingAnArnForACloudFormationModule(unittest.TestCase):
         self.assertEqual('Unable to resolve Org::ServiceName::UseCase::MODULE. CloudFormation modules are not yet supported.', str(cm.exception))
 
 
+class WhenGeneratingAnArnForACustomResource(unittest.TestCase):
+    def setUp(self):
+        self.arn_generator = ArnGenerator(account_config)
+
+    @mock_node_evaluator_setup()
+    def test_custom_prefix_returns_none(self):
+        resource = build_resource({'Type': 'Custom::MyCustomResource'})
+        arn = self.arn_generator.try_generate_arn('AnyName', resource, 'Ref')
+        self.assertIsNone(arn)
+
+    @mock_node_evaluator_setup()
+    def test_custom_prefix_returns_none_for_get_att(self):
+        resource = build_resource({'Type': 'Custom::MyCustomResource'})
+        arn = self.arn_generator.try_generate_arn('AnyName', resource, 'Arn')
+        self.assertIsNone(arn)
+
+    @mock_node_evaluator_setup()
+    def test_cloudformation_custom_resource_returns_none(self):
+        resource = build_resource({'Type': 'AWS::CloudFormation::CustomResource'})
+        arn = self.arn_generator.try_generate_arn('AnyName', resource, 'Ref')
+        self.assertIsNone(arn)
+
+
 class WhenGeneratingAnArnForAnIAMRoleAndValidatingSchema(unittest.TestCase):
     @mock_node_evaluator_setup()
     def test_with_no_properties(self):


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-cloudformation-iam-policy-validator/issues/15
*Description of changes:*
Adding support for customers opting into handling a custom resource

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
